### PR TITLE
CRONAPP-3995-Criar função para leitura de biometria digital Android/iOS

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -6,6 +6,7 @@
     <keywords>cordova,cronapp,plugin</keywords>
     <repo>https://github.com/CronApp/cordova-plugin-cronapp.git</repo>
 
+    <dependency id="cordova-plugin-androidx-adapter" version="^1.1.3"/>
     <dependency id="cordova-plugin-buildinfo" version="^2.0.2"/>
     <dependency id="cordova-plugin-device" version="^2.0.2"/>
     <dependency id="cordova-plugin-device-motion" version="^2.0.1"/>


### PR DESCRIPTION
## Problema
Apresenta erro de compilação após adicionar o plugin de biometria

## Solução
Adicionado o plugin cordova-plugin-androidx-adapter para resolver o problema.