### PR TITLE
CRONAPP-4157 - Utilização de API depreciada - UIWebView - cordova-plugin-cronapp-decimal-keyboard 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-cronapp",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "description": "Cordova Plugin Cronapp Dependencies",
   "main": "index.js",
   "scripts": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -21,7 +21,7 @@
     <dependency id="phonegap-plugin-barcodescanner" version="^8.0.1"/>
     <dependency id="cordova-plugin-camera" version="^4.0.3"/>
     <dependency id="cordova-plugin-ios-camera-permissions" version="^1.2.0"/>
-    <dependency id="cordova-plugin-cronapp-decimal-keyboard" version="^1.0.1"/>
+    <dependency id="cordova-plugin-cronapp-decimal-keyboard" version="^1.0.2"/>
     <dependency id="cordova-plugin-sqlite-2" version="^1.0.6"/>
     <dependency id="cordova-plugin-ionic-webview" version="^5.0.0"/>
     <dependency id="cordova-plugin-file-opener2" version="^3.0.5"/>


### PR DESCRIPTION
CRONAPP-4157 - Utilização de API depreciada - UIWebView - cordova-plugin-cronapp-decimal-keyboard

Solução
Removida referências à API UIWebView